### PR TITLE
Adding support for Init Functions 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build: build-testdata
 
 build-testdata:
 	$(MAKE) -C testdata/default build
+	$(MAKE) -C testdata/fail build
 	$(MAKE) -C testdata/kv build
 	$(MAKE) -C testdata/sql build
 	$(MAKE) -C testdata/logger build

--- a/docs/wasm-functions/multi-function-services.md
+++ b/docs/wasm-functions/multi-function-services.md
@@ -114,6 +114,26 @@ Here is an example of a route object that defines a scheduled task that executes
 
 You can define multiple scheduled tasks in the routes array.
 
+##### Init Functions
+
+In addition to HTTP and scheduled task routes, Tarmac also supports init functions.
+
+You can define an init function route by adding a route object with the following properties to the routes array:
+
+- `type` (required): For Init Functions, set to `init`.
+- `function` (required): The function to call when the service is initialized.
+
+Here is an example of a route object that defines an init function that executes the default function when the service is initialized:
+
+```json
+{
+  "type": "init",
+  "function": "default"
+}
+```
+
+You can define multiple init functions in the routes array. Functions will be executed before the server is fully started but after the WASM modules are loaded and callbacks are registered.
+
 ##### Functions
 
 Tarmac supports the ability for Functions to call other Functions using the Function to Function route. 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -85,6 +85,15 @@ func TestBadConfigs(t *testing.T) {
 	v.Set("wasm_function", "something-that-does-not-exist")
 	cfgs["invalid WASM path"] = v
 
+	// Failing init function
+	v = viper.New()
+	v.Set("enable_tls", false)
+	v.Set("listen_addr", "0.0.0.0:8443")
+	v.Set("disable_logging", true)
+	v.Set("enable_kvstore", false)
+	v.Set("wasm_function_config", "/testdata/tarmac-fail.json")
+	cfgs["failing init function"] = v
+
 	// Loop through bad configs, creating sub-tests as we go
 	for k, v := range cfgs {
 		t.Run("Testing "+k, func(t *testing.T) {

--- a/testdata/fail/Makefile
+++ b/testdata/fail/Makefile
@@ -1,0 +1,10 @@
+## Makefile for Go example for Tarmac WASM functions
+
+build:
+	## Run TinyGo build via Docker because its easier
+	docker run --rm -v `pwd`:/build -w /build tinygo/tinygo:0.25.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+
+docker-compose:
+	docker compose up
+
+run: build docker-compose

--- a/testdata/fail/docker-compose.yml
+++ b/testdata/fail/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  tarmac-example:
+    image: madflojo/tarmac
+    ports:
+      - 80:8080
+    environment:
+      - "APP_ENABLE_TLS=false"
+      - "APP_LISTEN_ADDR=0.0.0.0:8080"
+      - "APP_DEBUG=true"
+    volumes:
+      - "./:/functions"

--- a/testdata/fail/go.mod
+++ b/testdata/fail/go.mod
@@ -1,0 +1,10 @@
+module github.com/tarmac-project/tarmac/testdata/fail
+
+go 1.21
+
+require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
+
+require (
+	github.com/valyala/fastjson v1.6.4 // indirect
+	github.com/wapc/wapc-guest-tinygo v0.3.3 // indirect
+)

--- a/testdata/fail/go.sum
+++ b/testdata/fail/go.sum
@@ -1,0 +1,8 @@
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
+github.com/tarmac-project/tarmac/pkg/sdk v0.5.0 h1:QKsEf6SXTYrJM9/B4cNoM4RS3/rzuViJaiutEcdSRZQ=
+github.com/tarmac-project/tarmac/pkg/sdk v0.5.0/go.mod h1:UTKYV0QFdkJDgV2sJcnuCujVy49MCd8bgi2JmwviJ6E=
+github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
+github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
+github.com/wapc/wapc-guest-tinygo v0.3.3 h1:jLebiwjVSHLGnS+BRabQ6+XOV7oihVWAc05Hf1SbeR0=
+github.com/wapc/wapc-guest-tinygo v0.3.3/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=

--- a/testdata/fail/main.go
+++ b/testdata/fail/main.go
@@ -1,0 +1,20 @@
+// This program is a test program used to facilitate unit testing with Tarmac.
+package main
+
+import (
+	"fmt"
+	"github.com/tarmac-project/tarmac/pkg/sdk"
+)
+
+func main() {
+	// Initialize the Tarmac SDK
+	_, err := sdk.New(sdk.Config{Namespace: "test-service", Handler: Handler})
+	if err != nil {
+		return
+	}
+}
+
+func Handler(payload []byte) ([]byte, error) {
+	// Return a happy message
+	return []byte(""), fmt.Errorf("This is a test error")
+}

--- a/testdata/tarmac-fail.json
+++ b/testdata/tarmac-fail.json
@@ -1,0 +1,18 @@
+{
+  "services": {
+    "test-service": {
+      "name": "test-service",
+      "functions": {
+        "fail": {
+          "filepath": "/testdata/fail/tarmac.wasm"
+        }
+      },
+      "routes": [
+        {
+          "type": "init",
+          "function": "fail"
+        }
+      ]
+    }
+  }
+}

--- a/testdata/tarmac.json
+++ b/testdata/tarmac.json
@@ -21,6 +21,10 @@
       },
       "routes": [
         {
+          "type": "init",
+          "function": "default"
+        },
+        {
           "type": "http",
           "path": "/",
           "methods": ["GET", "POST", "PUT"],


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added "init functions" to Tarmac, allowing users to define initialization functions that execute when the service starts. This feature enhances the flexibility and control over service startup behavior.
- New Feature: Updated the `Run` method in `Server` struct to support initializing routes, executing init functions, and scheduling tasks. This change improves the server's functionality and versatility.
- Test: Introduced a new test case for handling failing init functions, improving the robustness of our testing suite.
- Chore: Added a new build target `build-testdata` to the Makefile, facilitating the building of additional test data.
- Documentation: Updated documentation to include details about the new "init functions" feature, providing users with necessary guidance on its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->