### PR TITLE
Minor Updates

### DIFF
--- a/docs/running-tarmac/configuration.md
+++ b/docs/running-tarmac/configuration.md
@@ -29,6 +29,8 @@ When using Environment Variables, all configurations are prefixed with `APP_`. T
 | `APP_ENABLE_PPROF` | `enable_pprof` | `bool` | Enable PProf Collection HTTP end-points |
 | `APP_ENABLE_KVSTORE` | `enable_kvstore` | `bool` | Enable the KV Store |
 | `APP_KVSTORE_TYPE` | `kvstore_type` | `string` | Select KV Store to use (Options: `redis`, `cassandra`, `boltdb`, `in-memory`, `internal`)|
+| `APP_ENABLE_SQL` | `enable_sql` | `bool` | Enable the SQL Store |
+| `APP_SQL_TYPE` | `sql_type` | `string` | Select SQL Store to use (Options: `postgres`, `mysql`)|
 
 ## Consul Format
 

--- a/docs/running-tarmac/sql.md
+++ b/docs/running-tarmac/sql.md
@@ -8,7 +8,7 @@ Tarmac has support for multiple SQL datastore storage systems. These datastores 
 configuration options within Tarmac. As a WASM Function developer, you do not need to know the underlying datastore 
 when writing the function. Callbacks for accessing the SQL datastore are generic across all supported datastores.
 
-To start using a SQL datastore, set the `enable_sqlstore` configuration to `true` and specify which supported 
+To start using a SQL datastore, set the `enable_sql` configuration to `true` and specify which supported 
 platform to use with the `sqlstore_type` variable.
 
 The below table outlines the different available options.


### PR DESCRIPTION
Simple documentation update for something that should have been there but was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Introduced the ability to enable and select a SQL store through environment variables. This allows users to choose between `postgres` and `mysql` as their preferred SQL store.
- Documentation: Updated the configuration documentation to reflect these changes. The `enable_sqlstore` option has been renamed to `enable_sql`, and `sqlstore_type` is now used to specify the supported platform. 

These changes provide users with more flexibility and clarity when configuring their SQL data storage options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->