### PR TITLE
Adding ARM support for Docker Build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,4 +33,5 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: madflojo/tarmac:latest
+          # tag with the git tag v*
+          tags: madflojo/tarmac:${{ github.ref_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
 jobs:
   build-latest:
     runs-on: ubuntu-latest
@@ -16,9 +18,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+      - name: Build and push (main)
         id: docker_build
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: madflojo/tarmac:unstable
+      - name: Build and push (tag)
+        id: docker_build_tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: madflojo/tarmac:latest


### PR DESCRIPTION
closes #88

Also adds a docker build and push for tags, which I dunno why was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Implemented a new CI job to build and push Docker images for both the main branch and version-tagged commits, supporting multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->