### PR TITLE
chore(ci): adding a latest tag to releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: madflojo/tarmac:unstable
+      - name: Checkout code and fetch all tags
+        run: |
+          git fetch --tags
+          echo "current_tag=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
+          echo "latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
       - name: Build and push (tag)
         id: docker_build_tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -34,4 +39,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           # tag with the git tag v*
-          tags: madflojo/tarmac:${{ github.ref_name }}
+          tags: |
+            madflojo/tarmac:${{ github.ref_name }}
+            ${{ env.latest_tag == env.current_tag && 'madflojo/tarmac:latest' }}


### PR DESCRIPTION
This, in theory (YOLO), will add the latest tag to the release build if the release is the latest and greatest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved CI/CD workflow to conditionally tag Docker images as `latest` based on version comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->