### PR TITLE
fix(logging): removes http headers from logs

### DIFF
--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -105,7 +105,6 @@ func (srv *Server) WASMHandler(w http.ResponseWriter, r *http.Request, _ httprou
 				"method":         r.Method,
 				"remote-addr":    r.RemoteAddr,
 				"http-protocol":  r.Proto,
-				"headers":        r.Header,
 				"content-length": r.ContentLength,
 			}).Debugf("Error reading HTTP payload - %s", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -120,7 +119,6 @@ func (srv *Server) WASMHandler(w http.ResponseWriter, r *http.Request, _ httprou
 			"method":         r.Method,
 			"remote-addr":    r.RemoteAddr,
 			"http-protocol":  r.Proto,
-			"headers":        r.Header,
 			"content-length": r.ContentLength,
 		}).Debugf("Error executing WASM module - %s", err)
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
fixes #109

This change removes the HTTP headers from debug logs, which could contain sensitive information such as pre-shared tokens, etc.