### PR TITLE
Adding retries to Init Functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build-testdata:
 	$(MAKE) -C testdata/sql build
 	$(MAKE) -C testdata/logger build
 	$(MAKE) -C testdata/function build
+	$(MAKE) -C testdata/successafter5 build
 
 tests: build tests-nobuild
 tests-nobuild: tests-base tests-redis tests-cassandra tests-mysql tests-postgres tests-boltdb tests-inmemory

--- a/docs/wasm-functions/multi-function-services.md
+++ b/docs/wasm-functions/multi-function-services.md
@@ -124,7 +124,7 @@ You can define an init function route by adding a route object with the followin
 - `type` (required): For Init Functions, set to `init`.
 - `function` (required): The function to call when the service is initialized.
 - `retries` (optional): The number of times to retry the function if it fails. Defaults to 0.
-- `frequency` (optional): The frequency in seconds to retry the function if it fails. Multiplied by the retry count. Defaults to 1.
+- `frequency` (optional): The frequency in seconds to retry the function if it fails. Exponential backoff is used. Defaults to 1.
 
 Here is an example of a route object that defines an init function that executes the default function when the service is initialized:
 

--- a/docs/wasm-functions/multi-function-services.md
+++ b/docs/wasm-functions/multi-function-services.md
@@ -101,7 +101,7 @@ You can define a scheduled task route by adding a route object with the followin
 
 - `type` (required): For Schedule Tasks, set to `scheduled_task`.
 - `function` (required): The function to call when the task is executed.
-- `frequency` (required): The frequency in seconds to  execute the function.
+- `frequency` (required): The frequency in seconds to execute the function.
 
 Here is an example of a route object that defines a scheduled task that executes the default function every 15 seconds:
 
@@ -123,6 +123,8 @@ You can define an init function route by adding a route object with the followin
 
 - `type` (required): For Init Functions, set to `init`.
 - `function` (required): The function to call when the service is initialized.
+- `retries` (optional): The number of times to retry the function if it fails. Defaults to 0.
+- `frequency` (optional): The frequency in seconds to retry the function if it fails. Multiplied by the retry count. Defaults to 1.
 
 Here is an example of a route object that defines an init function that executes the default function when the service is initialized:
 
@@ -141,6 +143,7 @@ Tarmac supports the ability for Functions to call other Functions using the Func
 
 You can define a function route by adding a route object with the following properties to the route array.
 
+- `type` (required): For Function to Function routes, set to `function`.
 - `function` (required): The function to call when executed.
 
 Here is an example of a route object that defines the "function1" function.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -687,7 +687,7 @@ func (srv *Server) Run() error {
 			for _, r := range initRoutes {
 				srv.log.Infof("Executing Init Function %s", r.Function)
 				var success, retries int
-				delay = r.Frequency
+				delay := r.Frequency
 				for success == 0 && retries <= r.Retries {
 					// Execute the function
 					_, err := srv.runWASM(r.Function, "handler", []byte(""))

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -693,7 +693,7 @@ func (srv *Server) Run() error {
 					if err != nil {
 						srv.log.Errorf("Error executing Init Function %s - %s", r.Function, err)
 						retries++
-						// Wait exponentially longer between retries
+						// Wait longer between retries
 						<-time.After(time.Duration(retries*r.Frequency) * time.Second)
 						continue
 					}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -617,11 +617,11 @@ func (srv *Server) Run() error {
 				"service": svcName,
 			}).Infof("Registering Routes from Service %s", svcName)
 			funcRoutes := make(map[string]string)
-			initRoutes := []string{}
+			initRoutes := []config.Route{}
 			for _, r := range svcCfg.Routes {
 				// Copy init functions for later execution
 				if r.Type == "init" {
-					initRoutes = append(initRoutes, r.Function)
+					initRoutes = append(initRoutes, r)
 				}
 
 				// Register HTTP based functions with the HTTP router
@@ -689,11 +689,23 @@ func (srv *Server) Run() error {
 			}
 
 			// Execute init functions
-			for _, f := range initRoutes {
-				srv.log.Infof("Executing Init Function %s", f)
-				_, err := srv.runWASM(f, "handler", []byte(""))
-				if err != nil {
-					return fmt.Errorf("error executing init function %s - %s", f, err)
+			for _, r := range initRoutes {
+				srv.log.Infof("Executing Init Function %s", r.Function)
+				var success, retries int
+				for success == 0 && retries <= r.Retries {
+					// Execute the function
+					_, err := srv.runWASM(r.Function, "handler", []byte(""))
+					if err != nil {
+						srv.log.Errorf("Error executing Init Function %s - %s", r.Function, err)
+						retries++
+						// Wait exponentially longer between retries
+						<-time.After(time.Duration(retries*r.Frequency) * time.Second)
+						continue
+					}
+					success = 1
+				}
+				if success == 0 {
+					return fmt.Errorf("init function %s exceeded retries", r.Function)
 				}
 			}
 		}

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -328,7 +328,7 @@ func TestInitFuncs(t *testing.T) {
 				t.Errorf("Run unexpectedly stopped - %s", err)
 			}
 
-			if ctx.Err() == context.DeadlineExceeded && !tc.err {
+			if ctx.Err() == context.DeadlineExceeded && tc.err {
 				t.Fatalf("Server did not fail as expected")
 			}
 		})

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -315,7 +315,7 @@ func TestInitFuncs(t *testing.T) {
 				<-ctx.Done()
 				defer srv.Stop()
 				if ctx.Err() == context.DeadlineExceeded && tc.err {
-					t.Fatalf("Timeout waiting for server to start")
+					t.Errorf("Timeout waiting for server to start")
 				}
 			}()
 

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -298,7 +298,9 @@ func TestInitFuncs(t *testing.T) {
 				t.Fatalf("Unexpected error creating temp file - %s", err)
 			}
 			defer os.Remove(fh.Name())
-			fh.Write(tc.config)
+			if _, err := fh.Write(tc.config); err != nil {
+				t.Fatalf("Unexpected error writing to temp file - %s", err)
+			}
 			fh.Close()
 			tc.cfg.Set("wasm_function_config", fh.Name())
 
@@ -326,7 +328,7 @@ func TestInitFuncs(t *testing.T) {
 				t.Errorf("Run unexpectedly stopped - %s", err)
 			}
 
-			if ctx.Err() == context.DeadlineExceeded && tc.err {
+			if ctx.Err() == context.DeadlineExceeded && !tc.err {
 				t.Fatalf("Server did not fail as expected")
 			}
 		})

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -307,7 +307,7 @@ func TestInitFuncs(t *testing.T) {
 			defer srv.Stop()
 
 			// Time out after 2 seconds
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			defer cancel()
 			go func() {
 				<-ctx.Done()

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -280,6 +280,16 @@ func TestInitFuncs(t *testing.T) {
 	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"successafter5":{"filepath":"/testdata/successafter5/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","retries":10,"function":"successafter5"}]}}}`)
 	tt = append(tt, tc)
 
+	tc = InitFuncTestCase{name: "Fail After 10 Retries", cfg: viper.New()}
+	tc.cfg.Set("disable_logging", false)
+	tc.cfg.Set("debug", true)
+	tc.cfg.Set("listen_addr", "localhost:9001")
+	tc.cfg.Set("kvstore_type", "in-memory")
+	tc.cfg.Set("enable_kvstore", true)
+	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"fail":{"filepath":"/testdata/fail/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","retries":10,"function":"fail"}]}}}`)
+	tc.err = true
+	tt = append(tt, tc)
+
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			// Write the config to a temp file

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -261,6 +261,25 @@ func TestInitFuncs(t *testing.T) {
 	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"default":{"filepath":"/testdata/default/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","function":"default"}]}}}`)
 	tt = append(tt, tc)
 
+	tc = InitFuncTestCase{name: "Fails", cfg: viper.New()}
+	tc.cfg.Set("disable_logging", false)
+	tc.cfg.Set("debug", true)
+	tc.cfg.Set("listen_addr", "localhost:9001")
+	tc.cfg.Set("kvstore_type", "in-memory")
+	tc.cfg.Set("enable_kvstore", true)
+	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"fail":{"filepath":"/testdata/fail/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","function":"fail"}]}}}`)
+	tc.err = true
+	tt = append(tt, tc)
+
+	tc = InitFuncTestCase{name: "Success After 5 Retries", cfg: viper.New()}
+	tc.cfg.Set("disable_logging", false)
+	tc.cfg.Set("debug", true)
+	tc.cfg.Set("listen_addr", "localhost:9001")
+	tc.cfg.Set("kvstore_type", "in-memory")
+	tc.cfg.Set("enable_kvstore", true)
+	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"successafter5":{"filepath":"/testdata/successafter5/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","retries":10,"function":"successafter5"}]}}}`)
+	tt = append(tt, tc)
+
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			// Write the config to a temp file
@@ -282,6 +301,7 @@ func TestInitFuncs(t *testing.T) {
 			defer cancel()
 			go func() {
 				<-ctx.Done()
+				defer srv.Stop()
 				if ctx.Err() == context.DeadlineExceeded && tc.err {
 					t.Fatalf("Timeout waiting for server to start")
 				}

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"os"
@@ -237,6 +238,67 @@ func TestFullService(t *testing.T) {
 				}
 			})
 
+		})
+	}
+}
+
+type InitFuncTestCase struct {
+	name   string
+	cfg    *viper.Viper
+	config []byte
+	err    bool
+}
+
+func TestInitFuncs(t *testing.T) {
+	var tt []InitFuncTestCase
+
+	tc := InitFuncTestCase{name: "Default", cfg: viper.New()}
+	tc.cfg.Set("disable_logging", false)
+	tc.cfg.Set("debug", true)
+	tc.cfg.Set("listen_addr", "localhost:9001")
+	tc.cfg.Set("kvstore_type", "in-memory")
+	tc.cfg.Set("enable_kvstore", true)
+	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"default":{"filepath":"/testdata/default/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","function":"default"}]}}}`)
+	tt = append(tt, tc)
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// Write the config to a temp file
+			fh, err := os.CreateTemp("", "*.json")
+			if err != nil {
+				t.Fatalf("Unexpected error creating temp file - %s", err)
+			}
+			defer os.Remove(fh.Name())
+			fh.Write(tc.config)
+			fh.Close()
+			tc.cfg.Set("wasm_function_config", fh.Name())
+
+			// Create the server
+			srv := New(tc.cfg)
+			defer srv.Stop()
+
+			// Time out after 2 seconds
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			go func() {
+				<-ctx.Done()
+				if ctx.Err() == context.DeadlineExceeded && tc.err {
+					t.Fatalf("Timeout waiting for server to start")
+				}
+			}()
+
+			// Start the server
+			err = srv.Run()
+			if err != nil && err != ErrShutdown {
+				if tc.err {
+					return
+				}
+				t.Errorf("Run unexpectedly stopped - %s", err)
+			}
+
+			if ctx.Err() == context.DeadlineExceeded && tc.err {
+				t.Fatalf("Server did not fail as expected")
+			}
 		})
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,7 +73,7 @@ type Route struct {
 	// If no frequency is defined, an error will occur.
 	//
 	// When defined as an init route, frequency is used to define the interval in seconds between retries.
-	// As the number of retries increases, the interval between retries will increase exponentially.
+	// As the number of retries increases, the interval will be multiplied by the retry number.
 	// If no frequency is defined, the default value is 1 second.
 	Frequency int `json:"frequency,omitempty"`
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,13 @@ type Function struct {
 
 // Route defines available routes for the service.
 type Route struct {
-	// Type defines the protocol used for the route, examples are "http", "nats", "scheduled_task", etc.
+	// Type defines the Route type for the function.
+	//
+	// Valid types are:
+	// - http - HTTP based routes
+	// - function - Function to Function calls
+	// - scheduled_task - Scheduled function calls
+	// - init - Initialization functions
 	Type string `json:"type"`
 
 	// Path defines the path for HTTP types.
@@ -61,13 +67,39 @@ type Route struct {
 	// Function defines the Function to execute when this route is called.
 	Function string `json:"function"`
 
-	// Frequency is used to define the frequency of scheduled_task routes in seconds.
+	// Frequency is used for both scheduled_task and init routes, with the value being the interval in seconds.
+	//
+	// When defined as an scheduled_task route, frequency is the interval at which tasks are executed.
+	// If no frequency is defined, an error will occur.
+	//
+	// When defined as an init route, frequency is used to define the interval in seconds between retries.
+	// As the number of retries increases, the interval between retries will increase exponentially.
+	// If no frequency is defined, the default value is 1 second.
 	Frequency int `json:"frequency,omitempty"`
+
+	// Retries is used to define the number of retries for init routes.
+	// If the init route fails, it will be retried for the number of times defined with a exponential backoff.
+	// The default value is 0 which means no retries.
+	Retries int `json:"retries,omitempty"`
 }
 
-// ErrRouteNotFound is returned when a requested route is not found in the
-// service's route configuration.
-var ErrRouteNotFound = fmt.Errorf("route not found")
+var (
+	// ErrRouteNotFound is returned when a requested route is not found in the
+	// service's route configuration.
+	ErrRouteNotFound = fmt.Errorf("route not found")
+
+	// ErrInvalidConfig is returned when the configuration file does not contain the required fields or is otherwise
+	// invalid.
+	ErrInvalidConfig = fmt.Errorf("invalid configuration file")
+)
+
+const (
+	// DefaultPoolSize is the default number of instances of a function to create.
+	DefaultPoolSize = 100
+
+	// DefaultFrequency is the default frequency for init routes.
+	DefaultFrequency = 1
+)
 
 // Parse function reads the file specified and attempts to parse the contents into a Config instance.
 func Parse(filepath string) (*Config, error) {
@@ -87,6 +119,11 @@ func Parse(filepath string) (*Config, error) {
 		return &Config{}, fmt.Errorf("could not parse service configuration file: %w", err)
 	}
 
+	// Validate the configuration
+	if err := cfg.Validate(); err != nil {
+		return &Config{}, ErrInvalidConfig
+	}
+
 	// Populate the internal routes map
 	cfg.routes = make(map[string]string)
 	for _, svcCfg := range cfg.Services {
@@ -101,6 +138,56 @@ func Parse(filepath string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// Validate function checks the configuration for required fields and returns an error if any are missing.
+// Validate will also populate any default values for fields that are not defined.
+func (cfg *Config) Validate() error {
+	cfg.Lock()
+	defer cfg.Unlock()
+
+	// Loop through each service and validate the configuration
+	for sk, svcCfg := range cfg.Services {
+		// Validate the service name
+		if svcCfg.Name == "" {
+			return fmt.Errorf("service missing name: %w", ErrInvalidConfig)
+		}
+
+		// Validate functions
+		for fk, f := range svcCfg.Functions {
+			if f.Filepath == "" {
+				return fmt.Errorf("function missing filepath: %w", ErrInvalidConfig)
+			}
+			if f.PoolSize == 0 {
+				f.PoolSize = DefaultPoolSize
+				cfg.Services[sk].Functions[fk] = f
+			}
+		}
+
+		// Validate routes
+		for rk, r := range svcCfg.Routes {
+			if r.Type == "" || r.Function == "" {
+				return fmt.Errorf("route missing type or function: %w", ErrInvalidConfig)
+			}
+
+			// Validate the route type
+			switch r.Type {
+			case "http":
+				if r.Path == "" || len(r.Methods) == 0 {
+					return fmt.Errorf("http route missing path or methods: %w", ErrInvalidConfig)
+				}
+			case "scheduled_task":
+				if r.Frequency == 0 {
+					return fmt.Errorf("scheduled_task route missing frequency: %w", ErrInvalidConfig)
+				}
+			case "init":
+				if r.Frequency == 0 {
+					cfg.Services[sk].Routes[rk].Frequency = DefaultFrequency
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // RouteLookup searches the routes map for a given key and returns the corresponding function name if the key is found,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,7 +73,7 @@ type Route struct {
 	// If no frequency is defined, an error will occur.
 	//
 	// When defined as an init route, frequency is used to define the interval in seconds between retries.
-	// As the number of retries increases, the interval will be multiplied by the retry number.
+	// As the number of retries increases, the interval will exponentially increase.
 	// If no frequency is defined, the default value is 1 second.
 	Frequency int `json:"frequency,omitempty"`
 

--- a/testdata/successafter5/Makefile
+++ b/testdata/successafter5/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run -v `pwd`/:/build -w /build tinygo/tinygo:latest tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build tinygo/tinygo:0.25.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/successafter5/Makefile
+++ b/testdata/successafter5/Makefile
@@ -1,0 +1,10 @@
+## Makefile for Go example for Tarmac WASM functions
+
+build:
+	## Run TinyGo build via Docker because its easier
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:latest tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+
+docker-compose:
+	docker compose up
+
+run: build docker-compose

--- a/testdata/successafter5/docker-compose.yml
+++ b/testdata/successafter5/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  tarmac-example:
+    image: madflojo/tarmac
+    ports:
+      - 80:8080
+    environment:
+      - "APP_ENABLE_TLS=false"
+      - "APP_LISTEN_ADDR=0.0.0.0:8080"
+      - "APP_DEBUG=true"
+      - "APP_ENABLE_KVSTORE=true"
+      - "APP_KVSTORE_TYPE=in-memory"
+    volumes:
+      - "./:/functions"

--- a/testdata/successafter5/go.mod
+++ b/testdata/successafter5/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/successafter5
 
-go 1.22.3
+go 1.22
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/successafter5/go.mod
+++ b/testdata/successafter5/go.mod
@@ -1,0 +1,10 @@
+module github.com/tarmac-project/tarmac/testdata/successafter5
+
+go 1.22.3
+
+require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
+
+require (
+	github.com/valyala/fastjson v1.6.4 // indirect
+	github.com/wapc/wapc-guest-tinygo v0.3.3 // indirect
+)

--- a/testdata/successafter5/go.sum
+++ b/testdata/successafter5/go.sum
@@ -1,0 +1,8 @@
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
+github.com/tarmac-project/tarmac/pkg/sdk v0.5.0 h1:QKsEf6SXTYrJM9/B4cNoM4RS3/rzuViJaiutEcdSRZQ=
+github.com/tarmac-project/tarmac/pkg/sdk v0.5.0/go.mod h1:UTKYV0QFdkJDgV2sJcnuCujVy49MCd8bgi2JmwviJ6E=
+github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
+github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
+github.com/wapc/wapc-guest-tinygo v0.3.3 h1:jLebiwjVSHLGnS+BRabQ6+XOV7oihVWAc05Hf1SbeR0=
+github.com/wapc/wapc-guest-tinygo v0.3.3/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=

--- a/testdata/successafter5/main.go
+++ b/testdata/successafter5/main.go
@@ -51,7 +51,7 @@ func Handler(payload []byte) ([]byte, error) {
 
 	// If the counter is less than 5, return an error
 	if counterInt < 5 {
-		return []byte(""), fmt.Errorf(`Counter is less than 6`)
+		return []byte(""), fmt.Errorf(`Counter is less than 5`)
 	}
 
 	return []byte("Counter is greater than 5"), nil

--- a/testdata/successafter5/main.go
+++ b/testdata/successafter5/main.go
@@ -1,0 +1,58 @@
+// This program is a test program used to facilitate unit testing with Tarmac.
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/tarmac-project/tarmac/pkg/sdk"
+)
+
+var tarmac *sdk.Tarmac
+
+func main() {
+	var err error
+
+	// Initialize the Tarmac SDK
+	tarmac, err = sdk.New(sdk.Config{Namespace: "tarmac", Handler: Handler})
+	if err != nil {
+		return
+	}
+}
+
+func Handler(payload []byte) ([]byte, error) {
+	// Fetch the counter value from KV datastore
+	counter, err := tarmac.KV.Get("counter")
+	if err != nil {
+		// Assume that the counter does not exist
+		tarmac.Logger.Info(`Counter does not exist, creating a new one`)
+		err = tarmac.KV.Set("counter", []byte("0"))
+		if err != nil {
+			tarmac.Logger.Error(fmt.Sprintf("Failed to store counter via KVStore - %s", err))
+			return []byte(""), fmt.Errorf(`Failed to store counter via KVStore - %s`, err)
+		}
+	}
+
+	// Increment the counter
+	counterInt, err := strconv.Atoi(string(counter))
+	if err != nil {
+		return []byte(""), fmt.Errorf(`Failed to convert counter to int - %s`, err)
+	}
+	counterInt++
+	tarmac.Logger.Debug(fmt.Sprintf("Counter is now %d", counterInt))
+
+	// Store the new counter value
+	err = tarmac.KV.Set("counter", []byte(strconv.Itoa(counterInt)))
+	if err != nil {
+		tarmac.Logger.Error(fmt.Sprintf("Failed to store counter via KVStore - %s", err))
+		return []byte(""), fmt.Errorf(`Failed to store counter via KVStore - %s`, err)
+	}
+	tarmac.Logger.Debug(fmt.Sprintf("Stored new counter value %d", counterInt))
+
+	// If the counter is less than 5, return an error
+	if counterInt < 5 {
+		return []byte(""), fmt.Errorf(`Counter is less than 6`)
+	}
+
+	return []byte("Counter is greater than 5"), nil
+}


### PR DESCRIPTION
This Pull Request adds retries to Init functions. If an init function errors on boot, this will retry function execution until the number of retries is exceeded or the function succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new build target for the `successafter5` project.
  - Added new parameters `retries` and `frequency` for scheduling tasks and init functions.

- **Bug Fixes**
  - Corrected a typo in the `frequency` parameter documentation for scheduled tasks.

- **Documentation**
  - Updated documentation to include new parameters and corrected descriptions.

- **Tests**
  - Added comprehensive tests for server initialization scenarios and retry logic.

- **Chores**
  - Added Docker setup and dependencies for the `successafter5` example project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->