### PR TITLE
Adding stop on completion of init if no other routes are defined

### DIFF
--- a/cmd/tarmac/main.go
+++ b/cmd/tarmac/main.go
@@ -28,6 +28,7 @@ func main() {
 	cfg.SetDefault("boltdb_permissions", 0600)
 	cfg.SetDefault("boltdb_timeout", 5)
 	cfg.SetDefault("grpc_socket_path", "/grpc.sock")
+  cfg.SetDefault("run_mode", "daemon")
 
 	// Load Config
 	cfg.AddConfigPath("./conf")

--- a/cmd/tarmac/main.go
+++ b/cmd/tarmac/main.go
@@ -28,7 +28,7 @@ func main() {
 	cfg.SetDefault("boltdb_permissions", 0600)
 	cfg.SetDefault("boltdb_timeout", 5)
 	cfg.SetDefault("grpc_socket_path", "/grpc.sock")
-  cfg.SetDefault("run_mode", "daemon")
+	cfg.SetDefault("run_mode", "daemon")
 
 	// Load Config
 	cfg.AddConfigPath("./conf")

--- a/docs/running-tarmac/configuration.md
+++ b/docs/running-tarmac/configuration.md
@@ -32,6 +32,7 @@ When using Environment Variables, all configurations are prefixed with `APP_`. T
 | `APP_KVSTORE_TYPE` | `kvstore_type` | `string` | Select KV Store to use (Options: `redis`, `cassandra`, `boltdb`, `in-memory`, `internal`)|
 | `APP_ENABLE_SQL` | `enable_sql` | `bool` | Enable the SQL Store |
 | `APP_SQL_TYPE` | `sql_type` | `string` | Select SQL Store to use (Options: `postgres`, `mysql`)|
+| `APP_RUN_MODE` | `run_mode` | `string` | Select the run mode for Tarmac (Options: `daemon`, `job`). Default: `daemon`. The `job` option will cause Tarmac to exit after init functions are executed. |
 
 ## Consul Format
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -129,7 +129,7 @@ func (srv *Server) Run() error {
 	srv.scheduler = tasks.New()
 	defer srv.scheduler.Stop()
 
-	// Initalization Log Message
+	// Startup Log Message
 	srv.log.WithFields(logrus.Fields{
 		"run_mode":       srv.cfg.GetString("run_mode"),
 		"use_consul":     srv.cfg.GetBool("use_consul"),

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -258,6 +258,7 @@ func TestInitFuncs(t *testing.T) {
 	tc.cfg.Set("listen_addr", "localhost:9001")
 	tc.cfg.Set("kvstore_type", "in-memory")
 	tc.cfg.Set("enable_kvstore", true)
+	tc.cfg.Set("run_mode", "job")
 	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"default":{"filepath":"/testdata/default/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","function":"default"}]}}}`)
 	tt = append(tt, tc)
 
@@ -267,6 +268,7 @@ func TestInitFuncs(t *testing.T) {
 	tc.cfg.Set("listen_addr", "localhost:9001")
 	tc.cfg.Set("kvstore_type", "in-memory")
 	tc.cfg.Set("enable_kvstore", true)
+	tc.cfg.Set("run_mode", "job")
 	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"fail":{"filepath":"/testdata/fail/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","function":"fail"}]}}}`)
 	tc.err = true
 	tt = append(tt, tc)
@@ -277,6 +279,7 @@ func TestInitFuncs(t *testing.T) {
 	tc.cfg.Set("listen_addr", "localhost:9001")
 	tc.cfg.Set("kvstore_type", "in-memory")
 	tc.cfg.Set("enable_kvstore", true)
+	tc.cfg.Set("run_mode", "job")
 	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"successafter5":{"filepath":"/testdata/successafter5/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","retries":10,"function":"successafter5"}]}}}`)
 	tt = append(tt, tc)
 
@@ -286,6 +289,7 @@ func TestInitFuncs(t *testing.T) {
 	tc.cfg.Set("listen_addr", "localhost:9001")
 	tc.cfg.Set("kvstore_type", "in-memory")
 	tc.cfg.Set("enable_kvstore", true)
+	tc.cfg.Set("run_mode", "job")
 	tc.config = []byte(`{"services":{"test-service":{"name":"test-service","functions":{"fail":{"filepath":"/testdata/fail/tarmac.wasm","pool_size":1}},"routes":[{"type":"init","retries":10,"function":"fail"}]}}}`)
 	tc.err = true
 	tt = append(tt, tc)

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -327,10 +327,14 @@ func TestInitFuncs(t *testing.T) {
 				}
 				t.Errorf("Run unexpectedly stopped - %s", err)
 			}
+			if err == ErrShutdown && ctx.Err() == context.DeadlineExceeded && !tc.err {
+				t.Errorf("Server did not start and shutdown as expected")
+			}
 
 			if ctx.Err() == context.DeadlineExceeded && tc.err {
 				t.Fatalf("Server did not fail as expected")
 			}
+
 		})
 	}
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -21,6 +21,9 @@ type Telemetry struct {
 
 	// Wasm is a summary metric of the WASM guest module executions.
 	Wasm *prometheus.SummaryVec
+
+	// Routes is a gauge metric of the configured service routes.
+	Routes *prometheus.GaugeVec
 }
 
 // New creates and returns an initialized Telemetry instance with default metrics.
@@ -59,6 +62,13 @@ func New() *Telemetry {
 		[]string{"route"},
 	)
 
+	m.Routes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "service_routes",
+		Help: "Number of configured service routes",
+	},
+		[]string{"service", "type"},
+	)
+
 	return m
 }
 
@@ -68,4 +78,5 @@ func (t *Telemetry) Close() {
 	_ = prometheus.Unregister(t.Srv)
 	_ = prometheus.Unregister(t.Callbacks)
 	_ = prometheus.Unregister(t.Wasm)
+	_ = prometheus.Unregister(t.Routes)
 }

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -30,6 +30,10 @@ func TestNewTelemetry(t *testing.T) {
 			wasmLabels := prometheus.Labels{"route": "/wasm"}
 			tm.Wasm.With(wasmLabels).Observe(0.3)
 
+			routeLabels := prometheus.Labels{"service": "service1", "type": "http"}
+			tm.Routes.With(routeLabels).Inc()
+			tm.Routes.With(routeLabels).Dec()
+
 		})
 	}
 }


### PR DESCRIPTION
With this pull request, Tarmac will stop once the init functions have completed executing, as long as no other routes are defined. This can be used to create ad-hoc jobs with Tarmac, use your favorite container scheduler, and at the start, your init function will be executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detailed route tracking and metrics in the server, summarizing loaded routes and supporting application shutdown if no service routes are loaded.
  - Introduced a new configuration setting `run_mode` with a default of `"daemon"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->