### PR TITLE
Adding Maintenance Mode Toggle

### DIFF
--- a/docs/running-tarmac/configuration.md
+++ b/docs/running-tarmac/configuration.md
@@ -33,6 +33,7 @@ When using Environment Variables, all configurations are prefixed with `APP_`. T
 | `APP_ENABLE_SQL` | `enable_sql` | `bool` | Enable the SQL Store |
 | `APP_SQL_TYPE` | `sql_type` | `string` | Select SQL Store to use (Options: `postgres`, `mysql`)|
 | `APP_RUN_MODE` | `run_mode` | `string` | Select the run mode for Tarmac (Options: `daemon`, `job`). Default: `daemon`. The `job` option will cause Tarmac to exit after init functions are executed. |
+| `APP_ENABLE_MAINTENANCE_MODE` | `enable_maintenance_mode` | `bool` | Enable Maintenance Mode. When enabled, Tarmac will return a 503 for requests to `/ready` allowing the service to go into "maintenance mode". |
 
 ## Consul Format
 

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -25,6 +25,12 @@ func (srv *Server) Health(w http.ResponseWriter, _ *http.Request, _ httprouter.P
 // Ready is used to handle HTTP Ready requests to this service. Use this for readiness
 // probes or any checks that validate the service is ready to accept traffic.
 func (srv *Server) Ready(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	// Check if maintence mode is enabled and return 503
+	if srv.cfg.GetBool("enable_maintenance_mode") {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
 	// Check other stuff here like KV connectivity, health of dependent services, etc.
 	if srv.cfg.GetBool("enable_kvstore") {
 		err := srv.kv.HealthCheck()


### PR DESCRIPTION
Having a maintenance mode can be very useful for applications. This toggle will essentially allow users to set their services as "not ready," which, when combined with readiness probes, will cause traffic to divert from the instances that are "not ready".

A very useful feature to have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Maintenance Mode feature that returns a 503 status for requests to `/ready` when enabled.

- **Documentation**
  - Updated configuration documentation to include the new `APP_ENABLE_MAINTENANCE_MODE` environment variable.

- **Tests**
  - Added tests to verify the functionality of the new Maintenance Mode.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->