### PR TITLE
chore(upgrade): bump Go to 1.24 and TinyGo to 0.35

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21'
+        go-version: '1.24'
     - name: Execute Tests
       run: make build tests-base
     - name: Upload coverage to Codecov
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21'
+        go-version: '1.24'
     - name: Execute Tests
       run: make build tests-redis
     - name: Upload coverage to Codecov
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21'
+        go-version: '1.24'
     - name: Execute Tests
       run: make build tests-cassandra
     - name: Upload coverage to Codecov
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21'
+        go-version: '1.24'
     - name: Build Test WASM Modules
       run: make build
     - name: Execute Tests
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21'
+        go-version: '1.24'
     - name: Execute Tests
       run: make build tests-inmemory
     - name: Upload coverage to Codecov
@@ -96,7 +96,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21'
+        go-version: '1.24'
     - name: Execute Tests
       run: make build tests-mysql
     - name: Upload coverage to Codecov
@@ -111,7 +111,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21'
+        go-version: '1.24'
     - name: Execute Tests
       run: make build tests-postgres
     - name: Upload coverage to Codecov

--- a/example/echo/go/Makefile
+++ b/example/echo/go/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	mkdir -p functions
-	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.35.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.36.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/example/echo/go/Makefile
+++ b/example/echo/go/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	mkdir -p functions
-	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.34.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.35.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/example/echo/go/Makefile
+++ b/example/echo/go/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	mkdir -p functions
-	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.36.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.35.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/example/echo/go/go.mod
+++ b/example/echo/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/example/echo/go
 
-go 1.21
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/example/echo/go/go.mod
+++ b/example/echo/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/example/echo/go
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/example/tac/go/Makefile
+++ b/example/tac/go/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	mkdir -p functions
-	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.35.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.36.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/example/tac/go/Makefile
+++ b/example/tac/go/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	mkdir -p functions
-	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.34.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.35.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/example/tac/go/Makefile
+++ b/example/tac/go/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	mkdir -p functions
-	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.36.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.35.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/example/tac/go/go.mod
+++ b/example/tac/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/example/tac/go
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/example/tac/go/go.mod
+++ b/example/tac/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/example/tac/go
 
-go 1.21
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/tarmac-project/tarmac
 
-go 1.23.0
-
-toolchain go1.23.2
+go 1.24.1
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1
@@ -12,7 +10,6 @@ require (
 	github.com/madflojo/testcerts v1.4.0
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7
 	github.com/prometheus/client_golang v1.21.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.19.0
 	github.com/tarmac-project/hord v0.6.0
 	github.com/tarmac-project/hord/drivers/bbolt v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac
 
-go 1.24.1
+go 1.23.7
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUt
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
@@ -452,7 +450,6 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/sdk/go.mod
+++ b/pkg/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/pkg/sdk
 
-go 1.24.1
+go 1.23.7
 
 require (
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7

--- a/pkg/sdk/go.mod
+++ b/pkg/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/pkg/sdk
 
-go 1.20
+go 1.24.1
 
 require (
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7

--- a/testdata/base/default/Makefile
+++ b/testdata/base/default/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/default/Makefile
+++ b/testdata/base/default/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/default/Makefile
+++ b/testdata/base/default/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/default/go.mod
+++ b/testdata/base/default/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/default
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/default/go.mod
+++ b/testdata/base/default/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/default
 
-go 1.21
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/fail/Makefile
+++ b/testdata/base/fail/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/fail/Makefile
+++ b/testdata/base/fail/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/fail/Makefile
+++ b/testdata/base/fail/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/fail/go.mod
+++ b/testdata/base/fail/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/fail
 
-go 1.21
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/fail/go.mod
+++ b/testdata/base/fail/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/fail
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/function/Makefile
+++ b/testdata/base/function/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/function/Makefile
+++ b/testdata/base/function/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/function/Makefile
+++ b/testdata/base/function/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/function/go.mod
+++ b/testdata/base/function/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/function
 
-go 1.21
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/function/go.mod
+++ b/testdata/base/function/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/function
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/kv/Makefile
+++ b/testdata/base/kv/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/kv/Makefile
+++ b/testdata/base/kv/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/kv/Makefile
+++ b/testdata/base/kv/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/kv/go.mod
+++ b/testdata/base/kv/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/kv
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/kv/go.mod
+++ b/testdata/base/kv/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/kv
 
-go 1.21
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/logger/Makefile
+++ b/testdata/base/logger/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/logger/Makefile
+++ b/testdata/base/logger/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/logger/Makefile
+++ b/testdata/base/logger/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/logger/go.mod
+++ b/testdata/base/logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/logger
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/logger/go.mod
+++ b/testdata/base/logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/logger
 
-go 1.20
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/logger/go.sum
+++ b/testdata/base/logger/go.sum
@@ -1,4 +1,5 @@
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/tarmac-project/tarmac/pkg/sdk v0.5.0 h1:QKsEf6SXTYrJM9/B4cNoM4RS3/rzuViJaiutEcdSRZQ=
 github.com/tarmac-project/tarmac/pkg/sdk v0.5.0/go.mod h1:UTKYV0QFdkJDgV2sJcnuCujVy49MCd8bgi2JmwviJ6E=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=

--- a/testdata/base/sql/Makefile
+++ b/testdata/base/sql/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/sql/Makefile
+++ b/testdata/base/sql/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/sql/Makefile
+++ b/testdata/base/sql/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/sql/go.mod
+++ b/testdata/base/sql/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/sql
 
-go 1.24.1
+go 1.23.7
 
 require (
 	github.com/tarmac-project/protobuf-go v0.0.0-20241006222641-e31a4349f2b8

--- a/testdata/base/sql/go.mod
+++ b/testdata/base/sql/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/sql
 
-go 1.22.6
+go 1.24.1
 
 require (
 	github.com/tarmac-project/protobuf-go v0.0.0-20241006222641-e31a4349f2b8

--- a/testdata/base/successafter5/Makefile
+++ b/testdata/base/successafter5/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/successafter5/Makefile
+++ b/testdata/base/successafter5/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/successafter5/Makefile
+++ b/testdata/base/successafter5/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/base/successafter5/go.mod
+++ b/testdata/base/successafter5/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/successafter5
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/base/successafter5/go.mod
+++ b/testdata/base/successafter5/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/successafter5
 
-go 1.22
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/sdkv1/kv/Makefile
+++ b/testdata/sdkv1/kv/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/kv/Makefile
+++ b/testdata/sdkv1/kv/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/kv/Makefile
+++ b/testdata/sdkv1/kv/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/kv/go.mod
+++ b/testdata/sdkv1/kv/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/kv
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/sdkv1/kv/go.mod
+++ b/testdata/sdkv1/kv/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/kv
 
-go 1.21
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/sdkv1/logger/Makefile
+++ b/testdata/sdkv1/logger/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/logger/Makefile
+++ b/testdata/sdkv1/logger/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/logger/Makefile
+++ b/testdata/sdkv1/logger/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/logger/go.mod
+++ b/testdata/sdkv1/logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/logger
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/sdkv1/logger/go.mod
+++ b/testdata/sdkv1/logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/logger
 
-go 1.20
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/sdkv1/logger/go.sum
+++ b/testdata/sdkv1/logger/go.sum
@@ -1,4 +1,5 @@
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/tarmac-project/tarmac/pkg/sdk v0.5.0 h1:QKsEf6SXTYrJM9/B4cNoM4RS3/rzuViJaiutEcdSRZQ=
 github.com/tarmac-project/tarmac/pkg/sdk v0.5.0/go.mod h1:UTKYV0QFdkJDgV2sJcnuCujVy49MCd8bgi2JmwviJ6E=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=

--- a/testdata/sdkv1/sql/Makefile
+++ b/testdata/sdkv1/sql/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/sql/Makefile
+++ b/testdata/sdkv1/sql/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.34.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/sql/Makefile
+++ b/testdata/sdkv1/sql/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	## Run TinyGo build via Docker because its easier
-	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.35.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+	docker run --rm -v `pwd`/:/build -w /build -u root tinygo/tinygo:0.36.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/testdata/sdkv1/sql/go.mod
+++ b/testdata/sdkv1/sql/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/sql
 
-go 1.24.1
+go 1.23.7
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/sdkv1/sql/go.mod
+++ b/testdata/sdkv1/sql/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarmac-project/tarmac/testdata/sql
 
-go 1.20
+go 1.24.1
 
 require github.com/tarmac-project/tarmac/pkg/sdk v0.5.0
 

--- a/testdata/sdkv1/sql/go.sum
+++ b/testdata/sdkv1/sql/go.sum
@@ -1,4 +1,5 @@
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/tarmac-project/tarmac/pkg/sdk v0.5.0 h1:QKsEf6SXTYrJM9/B4cNoM4RS3/rzuViJaiutEcdSRZQ=
 github.com/tarmac-project/tarmac/pkg/sdk v0.5.0/go.mod h1:UTKYV0QFdkJDgV2sJcnuCujVy49MCd8bgi2JmwviJ6E=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=


### PR DESCRIPTION
Upgrading our Go and TinyGo versions is like trading in your old station wagon for a sleek sports car—faster, shinier, and just as likely to turn heads at the intersection of code and performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded the TinyGo Docker image from version 0.34.0 to 0.35.0 in multiple build setups.
	- Updated Go version requirements to 1.23.7 across various modules for enhanced language support.
	- Removed an unnecessary logging dependency from the main module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->