### PR TITLE
fix: potential panics and bugs

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -158,7 +158,6 @@ func New(cfg *viper.Viper) *Server {
 					if exists {
 						a.Value = slog.StringValue(levelLabel)
 					}
-					a.Value = slog.StringValue(levelLabel)
 				}
 			}
 
@@ -840,8 +839,11 @@ func (srv *Server) Run() error {
 							"error", err)
 						retries++
 						// Wait exponentially longer between retries
+						if delay < 1 {
+							delay = 1
+						}
 						<-time.After(time.Duration(delay) * time.Second)
-						delay *= delay
+						delay *= 2
 						continue
 					}
 					success = 1


### PR DESCRIPTION
This commit addresses two potential issues:

1.  A repeated line in the `ReplaceAttr` function in `pkg/app/app.go` has been removed. This was a bug that could cause incorrect log level reporting.
2.  The init function retry logic in `pkg/app/app.go` has been improved to prevent a potential infinite loop if the retry frequency was set to 0 or 1. A minimum delay of 1 second is now enforced, and the delay doubles with each retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected exponential backoff logic during initialization retries to ensure delays increase in a standard manner and always wait at least 1 second.
  * Improved log level handling to avoid redundant assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->