### PR TITLE
Potential fix for code scanning alert no. 84: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tarmac-project/tarmac/security/code-scanning/84](https://github.com/tarmac-project/tarmac/security/code-scanning/84)

In general, the issue is fixed by explicitly defining a `permissions:` block in the workflow so that the `GITHUB_TOKEN` has only the minimum access needed. Because this workflow only reads repository contents and sends coverage to an external service using its own secret token, `contents: read` is sufficient for all jobs.

The best way to fix this without changing existing functionality is to add a single, top-level `permissions:` block (so it applies to every job) with `contents: read`. This goes directly under the `name:` (or at the same level as `on:` and `jobs:`) in `.github/workflows/build.yml`. No per-job permissions are necessary because all jobs share the same needs: they only need to read the code. No additional imports or methods are involved, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to enhance build process security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->