### PR TITLE
Potential fix for code scanning alert no. 77: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: docker
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/tarmac-project/tarmac/security/code-scanning/77](https://github.com/tarmac-project/tarmac/security/code-scanning/77)

In general, the fix is to add an explicit `permissions` block to the workflow (at the root level or per-job) that grants only what the workflow needs. This ensures the `GITHUB_TOKEN` does not inherit broader default permissions like `contents: write`. For this workflow, all steps only need to read the repository (via `actions/checkout`) and then build and push Docker images to Docker Hub using credentials stored in secrets; they do not write back to the repository or manage PRs/issues. Therefore, `contents: read` is sufficient.

The best fix with minimal behavioral change is to add a root-level `permissions` block right under the `name: docker` line so it applies to all jobs in the workflow. Set it to:

```yaml
permissions:
  contents: read
```

No other changes are required: the steps will continue to function as before, and Docker Hub writes use `secrets.DOCKERHUB_*`, not `GITHUB_TOKEN`. All modifications are confined to `.github/workflows/docker.yml`, at the top of the file before the existing `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to grant contents read access for enhanced security and proper authorization controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->