### PR TITLE
Potential fix for code scanning alert no. 76: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,4 +1,6 @@
 name: Lint Commit Messages
+permissions:
+  contents: read
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/tarmac-project/tarmac/security/code-scanning/76](https://github.com/tarmac-project/tarmac/security/code-scanning/76)

In general, this issue is fixed by explicitly specifying a `permissions` block in the workflow (either at the root level or per job) to restrict the `GITHUB_TOKEN` to the minimal scopes needed. For a lint‑only workflow that just checks commit messages and does not need to push code, modify issues, or update pull requests, `contents: read` is sufficient.

For this specific workflow in `.github/workflows/commitlint.yml`, the best fix without changing functionality is to add a root‑level `permissions` block with `contents: read` right after the `name` (or before `jobs:`). This will apply to all jobs that don’t override permissions, including `commitlint`. No imports or additional methods are needed since this is a YAML configuration change only.

Concretely:
- Edit `.github/workflows/commitlint.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between line 1 (`name: Lint Commit Messages`) and line 2 (`on: [pull_request]`) or between `on:` and `jobs:`; either position is valid, but placing it after `name` keeps it prominent.
- No other steps, jobs, or configuration entries need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to include permissions settings for improved security governance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->