### PR TITLE
Potential fix for code scanning alert no. 56: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: lint
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/tarmac-project/tarmac/security/code-scanning/56](https://github.com/tarmac-project/tarmac/security/code-scanning/56)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. Since this is a lint-only workflow that checks Go code and does not need to push commits, modify releases, or manage issues, it only needs read access to repository contents. The least-privilege configuration is to set `permissions: contents: read` at the workflow root so it applies to all jobs.

Concretely, in `.github/workflows/lint.yml`, add a `permissions:` block after the `name: lint` line (before `on:`). This will apply to the `golangci` job (and any future jobs without their own `permissions:`) and limit the token to read-only repository contents, satisfying CodeQL while preserving existing behavior. No imports or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
