### PR TITLE
fix(app): register SQL exec callback for smoother ops ⚙️

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -525,6 +525,16 @@ func (srv *Server) Run() error {
 		if err != nil {
 			return fmt.Errorf("unable to register callback for sql query - %s", err)
 		}
+
+		err = router.RegisterCallback(callbacks.CallbackConfig{
+			Namespace:  DefaultNamespace,
+			Capability: "sql",
+			Operation:  "exec",
+			Func:       cbSQL.Exec,
+		})
+		if err != nil {
+			return fmt.Errorf("unable to register callback for sql exec - %s", err)
+		}
 	}
 
 	// Setup KVStore Callbacks


### PR DESCRIPTION
## Summary
Registers the SQL execute callback in app initialization so SQL exec operations are available at runtime.

## Changes
- Added SQL execute callback registration in `pkg/app/app.go`
- Kept callback wiring aligned with existing callback initialization flow

## Rationale
SQL query callback was wired, but SQL exec callback was missing, which caused SQL execution calls to be unavailable.

## Risk & Impact
- Breaking changes: no
- Performance/Security: no material impact expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added callback registration for SQL execution operations with error handling in the server initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->