### PR TITLE
ci: run required checks for merge queues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - master
       - main
   pull_request:
+  merge_group:
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,7 +1,9 @@
 name: Lint Commit Messages
 permissions:
   contents: read
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   commitlint:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,8 @@ on:
     tags:
       - v*
   pull_request:
-     
+  merge_group:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
       - actions
       - main
   pull_request:
+  merge_group:
 jobs:
   golangci:
     name: golangci


### PR DESCRIPTION
## Summary
Adds `merge_group` triggers to required validation workflows so GitHub merge queues run the same checks before landing changes.

## Changes
- Enable `merge_group` for build, Docker, lint, and commitlint workflows.
- Leave release-please push-only to avoid release side effects during queue validation.

## Validation
- `git diff --check`
- Ruby YAML parse over all `.github/workflows/*.yml`

## Risks
Low. This only expands workflow trigger events for existing validation jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to support merge queue operations, enhancing the pull request review and merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->